### PR TITLE
refactor(cli): Allow Showing Sensitive Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Refactor
+
+- Sensitive fields can be unmasked using `--show-sensitive` in `kdbx show` subcommand
+
 ## 0.10.0 (2025-09-03)
 
 ### Feat

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -36,6 +36,10 @@ pub struct Args {
     #[arg(short = 'P', long)]
     remove_key: bool,
 
+    /// Show sensitive fields
+    #[arg(long)]
+    show_sensitive: bool,
+
     /// KDBX file path
     #[arg(short, long, env = "KDBX_DATABASE", value_hint = ValueHint::FilePath)]
     database: PathBuf,
@@ -61,7 +65,7 @@ pub(crate) fn run(args: Args) -> Result<()> {
     if let Some(query) = query
         && let Some(entry) = find_entry(query, &db.root)
     {
-        put!("{}", show_entry(entry));
+        put!("{}", show_entry(entry, args.show_sensitive));
         return Ok(());
     }
 
@@ -77,7 +81,7 @@ pub(crate) fn run(args: Args) -> Result<()> {
         args.full_screen,
         false,
     ) {
-        put!("{}", show_entry(wrapped_entry.entry));
+        put!("{}", show_entry(wrapped_entry.entry, args.show_sensitive));
         return Ok(());
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -196,7 +196,7 @@ pub fn skim<T: EntryPath>(
             };
 
             let props = if show_preview {
-                Some(show_entry(e.get_entry()))
+                Some(show_entry(e.get_entry(), false))
             } else {
                 None
             };

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -18,7 +18,7 @@ fn test_show() {
         .assert();
     assert_cmd
         .success()
-        .stdout("Title: test-pwd\nUsername: test");
+        .stdout("Title: test-pwd\nUsername: test\nPassword: ******");
 }
 
 #[test]
@@ -36,4 +36,24 @@ fn test_show_no_interaction_not_found() {
     .write_stdin("test123")
     .assert()
     .stderr("Not found\n");
+}
+
+#[test]
+fn test_show_sensitive() {
+    let mut cmd = Command::cargo_bin(BIN_NAME).unwrap();
+    let assert_cmd = cmd
+        .args([
+            "show",
+            "--show-sensitive",
+            "-d",
+            "tests/files/test.kdbx",
+            "-k",
+            "tests/files/secret",
+            "test-pwd",
+        ])
+        .write_stdin("test123")
+        .assert();
+    assert_cmd
+        .success()
+        .stdout("Title: test-pwd\nUsername: test\nPassword: 1234");
 }


### PR DESCRIPTION
When executing `kdbx show`, sensitive fields are now displayed masked by
default.
Unmasked fields can be fetched by providing `--show-sensitive`
argument.
