### PR TITLE
build(keepass): bump to keepass 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -270,6 +270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-modes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,11 +286,11 @@ checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -339,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
  "cipher",
 ]
@@ -370,13 +379,13 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -393,11 +402,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
- "crypto-common",
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
  "inout",
 ]
 
@@ -470,6 +480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +533,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,10 +570,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -640,6 +677,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +704,15 @@ dependencies = [
  "dispatch2",
  "nix 0.30.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -819,9 +874,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1010,6 +1077,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1145,10 +1218,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1166,13 +1252,22 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1199,7 +1294,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1216,6 +1320,15 @@ dependencies = [
  "sysinfo",
  "toml",
  "uuid",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1324,6 +1437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,7 +1482,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1377,12 +1498,12 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "block-padding",
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1474,7 +1595,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
 ]
@@ -1505,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "keepass"
-version = "0.8.16"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d40cdb5c00770fddffcfc2ab4c1be0acd6cdd6e2a34da549fbbeaaf307134fe"
+checksum = "adee434c69bae0f57eae9a53a5590357df8f00f90e52def5c8496f8169d535b6"
 dependencies = [
  "aes",
  "base32",
@@ -1519,21 +1640,23 @@ dependencies = [
  "chrono",
  "cipher",
  "flate2",
- "getrandom",
+ "getrandom 0.4.2",
  "hex",
  "hex-literal",
- "hmac",
+ "hmac 0.13.0",
+ "hybrid-array",
  "js-sys",
+ "quick-xml",
  "rust-argon2",
  "salsa20",
- "secstr",
- "sha2",
+ "secrecy",
+ "serde",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "totp-lite",
  "twofish",
  "url",
  "uuid",
- "xml-rs",
  "zeroize",
 ]
 
@@ -1548,6 +1671,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1603,7 +1732,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1953,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2090,6 +2219,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2270,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2163,7 +2318,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2188,7 +2343,7 @@ checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.10.0",
  "compact_str",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "itertools",
  "kasuari",
@@ -2239,7 +2394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
  "bitflags 2.10.0",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
@@ -2418,10 +2573,11 @@ checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "salsa20"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
+ "cfg-if",
  "cipher",
 ]
 
@@ -2432,12 +2588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "secstr"
-version = "0.5.1"
+name = "secrecy"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04f657244f605c4cf38f6de5993e8bd050c8a303f86aeabff142d5c7c113e12"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "libc",
+ "zeroize",
 ]
 
 [[package]]
@@ -2500,6 +2656,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,8 +2684,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2526,8 +2695,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2761,7 +2941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2829,7 +3009,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher",
  "terminfo",
@@ -3019,10 +3199,10 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8e43134db17199f7f721803383ac5854edd0d3d523cc34dba321d6acfbe76c3"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3068,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "twofish"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+checksum = "0218ef702a91e18ba84dd516edf8df33a9f9fb4431d6ada13e6f9502c3bcb6fc"
 dependencies = [
  "cipher",
 ]
@@ -3083,9 +3263,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -3123,6 +3303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,7 +3339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "atomic",
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3215,6 +3401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,6 +3455,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,9 +3504,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -3694,6 +3923,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -3717,21 +4028,6 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "xml"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
-
-[[package]]
-name = "xml-rs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
-dependencies = [
- "xml",
-]
 
 [[package]]
 name = "yoke"
@@ -3849,3 +4145,9 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ clap_complete = "4.5"
 ctrlc = { version = "3.4", features = ["termination"] }
 env_logger = "0.11"
 human-panic = "2.0"
-keepass = { version = "0.8", features = ["save_kdbx4", "totp"] }
+keepass = { version = "0.12", features = ["save_kdbx4", "totp"] }
+
 url = "2.5"
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_warn"] }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::ValueHint;
-use keepass::db::{Entry, Node, Value};
+use keepass::db::fields;
 
 use crate::{Result, STDIN, keepass::save_database, utils::open_database_interactively};
 
@@ -28,7 +28,7 @@ pub(crate) fn run(args: Args) -> Result<()> {
     if !args.database.exists() {
         return Err("File does not exist".to_string().into());
     }
-    let (db, password) = open_database_interactively(
+    let (mut db, password) = open_database_interactively(
         &args.database,
         args.key_file.as_deref(),
         args.use_keyring,
@@ -66,25 +66,15 @@ pub(crate) fn run(args: Args) -> Result<()> {
         }
     };
 
-    let mut entry = Entry::new();
-    entry
-        .fields
-        .insert("Title".to_string(), Value::Unprotected(entry_title));
-    entry
-        .fields
-        .insert("UserName".to_string(), Value::Unprotected(entry_username));
-    entry.fields.insert(
-        "Password".to_string(),
-        Value::Protected(entry_password.as_bytes().into()),
-    );
-    if !totp_raw.trim().is_empty() {
-        entry.fields.insert(
-            "otp".to_string(),
-            Value::Protected(totp_raw.as_bytes().into()),
-        );
-    }
-    let mut db = db;
-    db.root.children.push(Node::Entry(entry));
+    db.root_mut().add_entry().edit(|entry| {
+        entry.set_unprotected(fields::TITLE, entry_title);
+        entry.set_unprotected(fields::USERNAME, entry_username);
+        entry.set_protected(fields::PASSWORD, entry_password.as_ref());
+
+        if !totp_raw.trim().is_empty() {
+            entry.set_protected("otp", totp_raw.as_ref());
+        }
+    });
 
     save_database(db, &args.database, args.key_file.as_deref(), password)?;
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -28,7 +28,7 @@ pub(crate) fn run(args: Args) -> Result<()> {
 
     let database_name = read_db_name();
 
-    let mut db = Database::new(Default::default());
+    let mut db = Database::new();
 
     db.meta.database_name = Some(database_name);
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -43,12 +43,11 @@ pub(crate) fn run(args: Args) -> Result<()> {
         false,
     )?;
 
-    let entries = &get_entries(&db.root, "");
-    for e in entries.iter() {
+    for entry in get_entries(&db) {
         if args.no_group {
-            wout!("{}", e.get_title());
+            wout!("{}", entry.get_title().unwrap_or_default());
         } else {
-            wout!("{}", e.entry_path());
+            wout!("{}", entry.entry_path());
         }
     }
 

--- a/src/commands/pwd.rs
+++ b/src/commands/pwd.rs
@@ -1,7 +1,7 @@
 use std::{io, path::PathBuf, thread, time};
 
 use clap::ValueHint;
-use keepass::db::Entry;
+use keepass::db::EntryRef;
 use log::*;
 
 use crate::{
@@ -68,7 +68,7 @@ pub(crate) fn run(args: Args) -> Result<()> {
     let query = args.entry.as_ref().map(String::as_ref);
 
     if let Some(query) = query
-        && let Some(entry) = find_entry(query, &db.root)
+        && let Some(entry) = find_entry(query, &db)
     {
         // Print password to stdout when pipe used
         // e.g. `kdbx pwd example.com | cat`
@@ -76,7 +76,7 @@ pub(crate) fn run(args: Args) -> Result<()> {
             put!("{}", entry.get_password().unwrap_or_default());
             return Ok(());
         }
-        return clip(entry, args.timeout);
+        return clip(&entry, args.timeout);
     }
 
     if args.no_interaction {
@@ -89,21 +89,21 @@ pub(crate) fn run(args: Args) -> Result<()> {
         return Err(format!("No single match for {}.", query.unwrap_or("[empty]")).into());
     }
 
-    if let Some(wrapped_entry) = skim(
-        &get_entries(&db.root, ""),
+    if let Some(entry) = skim(
+        get_entries(&db).collect::<Vec<_>>(),
         query.map(String::from),
         args.no_group,
         args.preview,
         args.full_screen,
         false,
     ) {
-        clip(wrapped_entry.entry, args.timeout)?
+        clip(&entry, args.timeout)?
     }
 
     Ok(())
 }
 
-fn clip(entry: &Entry, timeout: u8) -> Result<()> {
+fn clip(entry: &EntryRef<'_>, timeout: u8) -> Result<()> {
     let pwd: Pwd = entry.get_password().unwrap_or_default().to_string().into();
 
     if set_clipboard(Some(pwd)).is_err() {

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{ops::Deref, path::PathBuf};
 
 use clap::ValueHint;
 
@@ -63,9 +63,9 @@ pub(crate) fn run(args: Args) -> Result<()> {
     let query = args.entry.as_ref().map(String::as_ref);
 
     if let Some(query) = query
-        && let Some(entry) = find_entry(query, &db.root)
+        && let Some(entry) = find_entry(query, &db)
     {
-        put!("{}", show_entry(entry, args.show_sensitive));
+        put!("{}", show_entry(entry.deref(), args.show_sensitive));
         return Ok(());
     }
 
@@ -73,15 +73,15 @@ pub(crate) fn run(args: Args) -> Result<()> {
         return Err("Not found".to_string().into());
     }
 
-    if let Some(wrapped_entry) = skim(
-        &get_entries(&db.root, ""),
+    if let Some(entry) = skim(
+        get_entries(&db).collect::<Vec<_>>(),
         query.map(String::from),
         args.no_group,
         args.preview,
         args.full_screen,
         false,
     ) {
-        put!("{}", show_entry(wrapped_entry.entry, args.show_sensitive));
+        put!("{}", show_entry(&entry, args.show_sensitive));
         return Ok(());
     }
 

--- a/src/commands/totp.rs
+++ b/src/commands/totp.rs
@@ -1,11 +1,7 @@
 use std::{io, path::PathBuf};
 
 use clap::ValueHint;
-use keepass::{
-    db::{Entry, TOTP},
-    error::TOTPError,
-};
-use url::{Url, form_urlencoded};
+use keepass::db::EntryRef;
 
 use crate::{
     Result,
@@ -71,16 +67,16 @@ pub(crate) fn run(args: Args) -> Result<()> {
     let query = args.entry.as_ref().map(String::as_ref);
 
     if let Some(query) = query
-        && let Some(entry) = find_entry(query, &db.root)
+        && let Some(entry) = find_entry(query, &db)
     {
         // Print totp to stdout when pipe used
         // e.g. `kdbx totp example.com | cat`
         if !is_tty(io::stdout()) {
-            let totp = get_totp(entry, args.raw)?;
+            let totp = get_totp(&entry, args.raw)?;
             put!("{}", totp.as_ref());
             return Ok(());
         }
-        return clip(entry, args.raw);
+        return clip(&entry, args.raw);
     }
 
     if args.no_interaction {
@@ -93,23 +89,23 @@ pub(crate) fn run(args: Args) -> Result<()> {
         return Err(format!("No single match for {}.", query.unwrap_or("[empty]")).into());
     }
 
-    if let Some(wrapped_entry) = skim(
-        &get_entries(&db.root, ""),
+    if let Some(entry) = skim(
+        get_entries(&db).collect::<Vec<_>>(),
         query.map(String::from),
         args.no_group,
         args.preview,
         args.full_screen,
         true,
     ) {
-        clip(wrapped_entry.entry, args.raw)?
+        clip(&entry, args.raw)?
     }
 
     Ok(())
 }
 
-fn clip(entry: &Entry, raw: bool) -> Result<()> {
+fn clip(entry: &EntryRef<'_>, raw: bool) -> Result<()> {
     let totp = get_totp(entry, raw)?;
-    if set_clipboard(Some(totp)).is_err() {
+    if set_clipboard(Some(totp.into())).is_err() {
         return Err(format!(
             "Clipboard unavailable. Try use STDOUT, i.e. `kdbx totp '{}' | cat`.",
             entry.get_title().unwrap_or_default()
@@ -120,112 +116,20 @@ fn clip(entry: &Entry, raw: bool) -> Result<()> {
     Ok(())
 }
 
-fn get_totp(entry: &Entry, raw: bool) -> Result<Pwd> {
-    let raw_value = entry
-        .get_raw_otp_value()
-        .ok_or_else(|| "Entry has no TOTP secret".to_string())?;
-    let trimmed = raw_value.trim();
+fn get_totp(entry: &EntryRef<'_>, raw: bool) -> Result<Pwd> {
+    let totp = if raw {
+        entry
+            .get_raw_otp_value()
+            .ok_or_else(|| "Entry has no TOTP secret".to_string())?
+            .trim()
+            .to_string()
+    } else {
+        entry
+            .get_otp()?
+            .value_now()
+            .map_err(|e| format!("Unable to compute TOTP: {e}"))?
+            .code
+    };
 
-    if trimmed.is_empty() {
-        return Err("Entry has no TOTP secret".to_string().into());
-    }
-
-    if raw {
-        return Ok(trimmed.to_string().into());
-    }
-
-    let code = parse_totp(trimmed)?
-        .value_now()
-        .map_err(|e| format!("Unable to compute TOTP: {e}"))?
-        .code;
-
-    Ok(code.into())
-}
-
-fn parse_totp(raw_value: &str) -> Result<TOTP> {
-    match raw_value.parse::<TOTP>() {
-        Ok(otp) => Ok(otp),
-        Err(TOTPError::Base32) => {
-            let Some(normalized) = normalize_totp_secret(raw_value) else {
-                return Err("Unable to read TOTP: Base32 decoding error"
-                    .to_string()
-                    .into());
-            };
-
-            normalized
-                .parse::<TOTP>()
-                .map_err(|e| format!("Unable to read TOTP: {e}").into())
-        }
-        Err(err) => Err(format!("Unable to read TOTP: {err}").into()),
-    }
-}
-
-fn normalize_totp_secret(raw_value: &str) -> Option<String> {
-    let mut url = Url::parse(raw_value).ok()?;
-    let mut pairs: Vec<(String, String)> = url.query_pairs().into_owned().collect();
-    let mut changed = false;
-
-    for (key, value) in pairs.iter_mut() {
-        if key != "secret" {
-            continue;
-        }
-
-        let normalized = normalize_base32_secret(value);
-        if normalized != *value {
-            *value = normalized;
-            changed = true;
-        }
-    }
-
-    if !changed {
-        return None;
-    }
-
-    let mut serializer = form_urlencoded::Serializer::new(String::new());
-    for (key, value) in pairs {
-        serializer.append_pair(&key, &value);
-    }
-
-    url.set_query(Some(&serializer.finish()));
-
-    Some(url.to_string())
-}
-
-fn normalize_base32_secret(secret: &str) -> String {
-    let mut normalized: String = secret
-        .chars()
-        .filter(|c| !c.is_whitespace() && *c != '-')
-        .map(|c| c.to_ascii_uppercase())
-        .collect();
-
-    if !normalized.len().is_multiple_of(8) {
-        normalized.push_str(&"=".repeat(8 - (normalized.len() % 8)));
-    }
-
-    normalized
-}
-
-#[cfg(test)]
-mod tests {
-    use keepass::db::Value;
-
-    use super::*;
-
-    #[test]
-    fn parses_secret_with_spaces() {
-        let mut entry = Entry::new();
-        entry.fields.insert(
-            "otp".to_string(),
-            Value::Unprotected(
-                "otpauth://totp/example:demo?secret=JBSW%20Y3DP%20EHPK%203PXP&issuer=example&\
-                 digits=6"
-                    .to_string(),
-            ),
-        );
-
-        let otp = parse_totp(entry.get_raw_otp_value().unwrap()).expect("parsed totp");
-
-        assert_eq!(otp.get_secret(), "JBSWY3DPEHPK3PXP");
-        assert_eq!(otp.value_at(0).code.len(), 6);
-    }
+    Ok(totp.into())
 }

--- a/src/keepass.rs
+++ b/src/keepass.rs
@@ -6,7 +6,7 @@ use std::{
 
 use keepass::{
     Database, DatabaseKey,
-    db::{Entry, Group, Node, Value},
+    db::{Entry, EntryId, EntryRef, GroupId, fields},
     error::{DatabaseOpenError, DatabaseSaveError},
 };
 
@@ -86,20 +86,8 @@ pub fn show_entry(entry: &Entry, show_sensitive: bool) -> String {
             continue;
         }
 
-        let value_str = match value {
-            Value::Unprotected(s) => s.to_string(),
-            Value::Protected(p) => {
-                if show_sensitive {
-                    String::from_utf8(p.unsecure().to_vec()).unwrap_or_default()
-                } else {
-                    MASKED_VALUE.to_string()
-                }
-            }
-            Value::Bytes(b) => String::from_utf8(b.clone())
-                .unwrap_or_else(|_| format!("<bytes: {}>", hex::encode(b))),
-        };
+        let trimmed_value = value.get().trim();
 
-        let trimmed_value = value_str.trim();
         if !trimmed_value.is_empty() {
             fields.push(format!("{key}: {trimmed_value}"));
         }
@@ -123,105 +111,102 @@ fn read_file(file: Option<&Path>) -> io::Result<Option<Cursor<Vec<u8>>>> {
     }
 }
 
-pub fn get_entries(group: &Group, path: impl ToString) -> Vec<WrappedEntry<'_>> {
-    let mut entries = Vec::with_capacity(
-        group
-            .children
-            .iter()
-            .filter(|v| match v {
-                Node::Entry(_) => true,
-                Node::Group(_) => false,
-            })
-            .count(),
-    );
-    group.children.iter().for_each(|v| match v {
-        Node::Entry(entry) => entries.push(WrappedEntry {
-            path: format!("{}/{}", path.to_string(), group.name),
-            entry,
-        }),
-        Node::Group(child) => {
-            if !child.children.is_empty() {
-                entries.extend(get_entries(
-                    child,
-                    format!("{}/{}", path.to_string(), group.name),
-                ))
-            }
+/// Returns an iterator over all entries in the database, sorted by their path.
+pub fn get_entries(db: &Database) -> impl Iterator<Item = EntryRef<'_>> {
+    let mut ids = Vec::new();
+
+    fn collect_entries(db: &Database, group_id: GroupId, ids: &mut Vec<EntryId>) {
+        let Some(group) = db.group(group_id) else {
+            return;
+        };
+
+        let mut entries = Vec::new();
+        for entry in group.entries() {
+            let title = entry.get(fields::TITLE).unwrap_or_default().to_string();
+            entries.push((title, entry.id()));
         }
-    });
-    entries
-}
 
-pub struct WrappedEntry<'a> {
-    pub path: String,
-    pub entry: &'a Entry,
-}
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        ids.extend(entries.into_iter().map(|(_, id)| id));
 
-impl EntryPath for WrappedEntry<'_> {
-    fn entry_path(&self) -> String {
-        format!(
-            "{}/{}",
-            self.path,
-            self.entry.get_title().unwrap_or_default().to_owned(),
-        )
-    }
-
-    fn get_entry(&self) -> &Entry {
-        self.entry
-    }
-
-    fn get_title(&self) -> String {
-        self.entry.get_title().unwrap_or_default().to_owned()
-    }
-
-    fn has_totp(&self) -> bool {
-        self.entry
-            .get_raw_otp_value()
-            .map(|otp| !otp.trim().is_empty())
-            .unwrap_or(false)
-    }
-}
-
-pub fn find_entry<'a>(query: &str, group: &'a Group) -> Option<&'a Entry> {
-    get_entries(group, "").iter().find_map(|e| {
-        let entry_path = e.entry_path();
-        if entry_path.ends_with(query) {
-            Some(e.entry)
-        } else {
-            None
+        let mut groups = Vec::new();
+        for subgroup in group.groups() {
+            let name = subgroup.name.to_string();
+            groups.push((name, subgroup.id()));
         }
-    })
+
+        groups.sort_by(|a, b| a.0.cmp(&b.0));
+        for (_, subgroup_id) in groups {
+            collect_entries(db, subgroup_id, ids);
+        }
+    }
+
+    collect_entries(db, db.root().id(), &mut ids);
+
+    ids.into_iter().filter_map(move |id| db.entry(id))
+}
+
+pub fn find_entry<'a>(query: &str, db: &'a Database) -> Option<EntryRef<'a>> {
+    for entry in get_entries(db) {
+        if entry.entry_path().ends_with(query) {
+            return Some(entry);
+        }
+    }
+
+    None
 }
 
 pub trait EntryPath {
     fn entry_path(&self) -> String;
-    fn get_entry(&self) -> &Entry;
-    fn get_title(&self) -> String;
-    fn has_totp(&self) -> bool;
+}
+
+impl EntryPath for EntryRef<'_> {
+    fn entry_path(&self) -> String {
+        let mut path = Vec::new();
+
+        path.push(self.get_title().unwrap_or_default().to_string());
+
+        let mut current = Some(self.parent().id());
+        while let Some(group) = current.and_then(|id| self.database().group(id)) {
+            path.push(group.name.to_string());
+            current = group.parent().map(|p| p.id());
+        }
+
+        path.push("".to_string());
+
+        path.reverse();
+        path.join("/")
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use keepass::db::Value;
+    use keepass::db::fields;
 
     use super::*;
 
     #[test]
     fn test_find_entry() {
-        let mut group = Group::new("root");
-        let mut child = Group::new("child");
-        let mut entry = Entry::new();
-        entry.fields.insert(
-            "Title".to_string(),
-            Value::Unprotected("My Title".to_string()),
+        let mut db = Database::new();
+
+        let entry = db
+            .root_mut()
+            .edit(|g| g.name = "root".to_string())
+            .add_group()
+            .edit(|g| g.name = "child".to_string())
+            .add_entry()
+            .edit(|e| e.set_unprotected(fields::TITLE, "My Title".to_string()))
+            .id();
+
+        assert_eq!(
+            db.entry(entry).unwrap().entry_path(),
+            "/root/child/My Title"
         );
 
-        child.children.push(Node::Entry(entry.clone()));
-        group.children.push(Node::Group(child));
-
-        assert_eq!(find_entry("/root/child/My Title", &group), Some(&entry));
-        assert_eq!(find_entry("child/My Title", &group), Some(&entry));
-        assert_eq!(find_entry("My Title", &group), Some(&entry));
-        assert_eq!(find_entry("Title", &group), Some(&entry));
-        assert_eq!(find_entry("My Other Title", &group), None);
+        assert!(find_entry("/root/child/My Title", &db).is_some());
+        assert!(find_entry("child/My Title", &db).is_some());
+        assert!(find_entry("My Title", &db).is_some());
+        assert!(find_entry("Title", &db).is_some());
+        assert!(find_entry("My Other Title", &db).is_none());
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,10 +3,15 @@ use std::{
     error, fmt,
     fs::File,
     io::{self, Read},
+    ops::Deref,
     path::Path,
 };
 
-use keepass::{Database, error::DatabaseOpenError as KeepassOpenError};
+use keepass::{
+    Database,
+    db::{EntryRef, fields},
+    error::DatabaseOpenError as KeepassOpenError,
+};
 use log::*;
 use regex::Regex;
 use skim::{prelude::*, tui::options::PreviewLayout};
@@ -169,14 +174,14 @@ struct EntryItem {
     props: Option<String>,
 }
 
-pub fn skim<T: EntryPath>(
-    entries: &[T],
+pub fn skim<'a>(
+    entries: Vec<EntryRef<'a>>,
     query: Option<String>,
     hide_groups: bool,
     show_preview: bool,
     full_screen: bool,
     with_totp: bool,
-) -> Option<&T> {
+) -> Option<EntryRef<'a>> {
     let opts = SkimOptionsBuilder::default()
         .multi(false)
         .reverse(true)
@@ -210,9 +215,15 @@ pub fn skim<T: EntryPath>(
 
     let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
 
-    let entries = entries
-        .iter()
-        .filter(|e| if with_totp { e.has_totp() } else { true })
+    let mut entries = entries
+        .into_iter()
+        .filter(|e| {
+            if with_totp {
+                e.get_raw_otp_value().is_some()
+            } else {
+                true
+            }
+        })
         .collect::<Vec<_>>();
 
     entries
@@ -220,13 +231,13 @@ pub fn skim<T: EntryPath>(
         .enumerate()
         .map(|(idx, e)| {
             let title = if hide_groups {
-                e.get_title()
+                e.get(fields::TITLE).unwrap_or_default().to_string()
             } else {
                 e.entry_path()
             };
 
             let props = if show_preview {
-                Some(show_entry(e.get_entry(), false))
+                Some(show_entry(e.deref(), false))
             } else {
                 None
             };
@@ -238,7 +249,7 @@ pub fn skim<T: EntryPath>(
     // No more input expected, dropping sender
     drop(tx);
 
-    Skim::run_with(opts, Some(rx))
+    let res = Skim::run_with(opts, Some(rx))
         .map(|res| {
             if res.is_abort || res.selected_items.len() != 1 {
                 None
@@ -248,10 +259,16 @@ pub fn skim<T: EntryPath>(
                     .as_ref()
                     .as_any()
                     .downcast_ref::<EntryItem>()
-                    .map(|ei: &EntryItem| entries[ei.idx])
+                    .map(|ei: &EntryItem| ei.idx)
             }
         })
-        .unwrap()
+        .unwrap();
+
+    if let Some(idx) = res {
+        Some(entries.remove(idx))
+    } else {
+        None
+    }
 }
 
 impl SkimItem for EntryItem {

--- a/tests/totp.rs
+++ b/tests/totp.rs
@@ -73,5 +73,5 @@ fn test_totp_missing_secret() {
     .write_stdin("test123")
     .assert()
     .failure()
-    .stderr("Entry has no TOTP secret\n");
+    .stderr("No OTP record found\n");
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->
After a major refactor of the keepass crate, bring the kdbx up to the most recent, stable API version.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/daxartio/kdbx/blob/master/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/daxartio/kdbx/blob/master/CHANGELOG.md
-->
